### PR TITLE
Adds PaperCall link to sidebar

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -32,6 +32,7 @@ AUTHOR_FEED_RSS = None
 
 LINKS = (
         ('posts', '/posts'),
+        ('submit talk', 'https://www.papercall.io/clepy'),
         )
 
 # Social widget


### PR DESCRIPTION
There's no icon for it in FontAwesome (4 or 5) so I threw it in the sidebar after posts.

EDIT: Closes issue #9 