### PR TITLE
Add Mailing List Page

### DIFF
--- a/content/pages/mailing-list.md
+++ b/content/pages/mailing-list.md
@@ -1,0 +1,12 @@
+Title: Mailing List
+Date: 2019-04-13
+
+
+## Subscribe
+
+<form style="border:1px solid #ccc;padding:3px;text-align:center;" action="https://tinyletter.com/clepy" method="post" target="popupwindow" onsubmit="window.open('https://tinyletter.com/clepy', 'popupwindow', 'scrollbars=yes,width=800,height=600');return true"><p><label for="tlemail">Enter your email address</label></p><p><input type="text" style="width:140px" name="email" id="tlemail" /></p><input type="hidden" value="1" name="embed"/><input type="submit" value="Subscribe" /><p><a href="https://tinyletter.com" target="_blank">powered by TinyLetter</a></p></form>
+
+
+## Have News?
+
+Send it to <clevelandpython@gmail.com> to be included in the CLEpy Newsletter.

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -33,7 +33,6 @@ AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
 LINKS = (
-        ('mailing list', 'https://tinyletter.com/clepy'),
         ('posts', '/posts'),
         ('submit talk', 'https://www.papercall.io/clepy'),
         )


### PR DESCRIPTION
Resolves gh-29 : Add newsletter page

Includes sections on the page to subscribe via a tiny letter form, and a note about sending news to the CLEpy email address.