### PR TITLE
Home Page: Single letter typo fix.

### DIFF
--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -4,6 +4,6 @@ URL:
 save_as: index.html
 template: home
 
-CLEpy is the home of the Cleveland Python community and a montly meetup:
+CLEpy is the home of the Cleveland Python community and a monthly meetup:
 
 [Meetup Details](https://www.meetup.com/Cleveland-Area-Python-Interest-Group){: aria-label='GitHub' }


### PR DESCRIPTION
Changes "montly meetup" to "monthly meetup."